### PR TITLE
Bump flex to ^1.17, v1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/log": "^1.1",
         "symfony/console": "5.3.*",
         "symfony/dotenv": "5.3.*",
-        "symfony/flex": "^1.13",
+        "symfony/flex": "^1.17",
         "symfony/framework-bundle": "5.3.*",
         "symfony/lock": "5.3.*",
         "symfony/monolog-bundle": "^3.7",


### PR DESCRIPTION
https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down